### PR TITLE
Fix sentence breaking issue

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -434,37 +434,51 @@ function CN_KeepSpeechSynthesisActive() {
 function CN_SplitIntoSentences(text) {
 	var sentences = [];
 	var currentSentence = "";
-	
-	for(var i=0; i<text.length; i++) {
-		//
+
+	// Use temporary placeholders to prevent splitting inside numbers
+	text = text.replace(/(\d),(\d)/g, '$1\x01$2');
+	text = text.replace(/(\d)\.(\d)/g, '$1\x02$2');
+
+	for (var i = 0; i < text.length; i++) {
 		var currentChar = text[i];
-		
+
 		// Add character to current sentence
 		currentSentence += currentChar;
-		
+
 		// is the current character a delimiter? if so, add current part to array and clear
 		if (
 			// Latin punctuation
-		       currentChar == (CN_IGNORE_COMMAS?'.':',')
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : ':')
-			|| currentChar == '.' 
-			|| currentChar == '!' 
-			|| currentChar == '?' 
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : ';')
-			|| currentChar == '…'
-			// Chinese/japanese punctuation
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '、')
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '，')
-			|| currentChar == '。'
-			|| currentChar == '．'
-			|| currentChar == '！'
-			|| currentChar == '？'
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '；')
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '：')
-			) {
-			if (currentSentence.trim() != "") sentences.push(currentSentence.trim());
+			currentChar == (CN_IGNORE_COMMAS ? '.' : ',') ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : ':') ||
+			currentChar == '.' ||
+			currentChar == '!' ||
+			currentChar == '?' ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : ';') ||
+			currentChar == '…' ||
+			// Chinese/Japanese punctuation
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '、') ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '，') ||
+			currentChar == '。' ||
+			currentChar == '．' ||
+			currentChar == '！' ||
+			currentChar == '？' ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '；') ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '：')
+		) {
+			if (currentSentence.trim() !== "") {
+				// Replace placeholders back to original strings
+				currentSentence = currentSentence.replace(/\x01/g, ',').replace(/\x02/g, '.');
+				sentences.push(currentSentence.trim());
+			}
 			currentSentence = "";
 		}
+	}
+
+	// Add last sentence if any
+	if (currentSentence.trim() !== "") {
+		// Replace placeholders back to original strings
+		currentSentence = currentSentence.replace(/\x01/g, ',').replace(/\x02/g, '.');
+		sentences.push(currentSentence.trim());
 	}
 	
 	return sentences;

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -435,9 +435,11 @@ function CN_SplitIntoSentences(text) {
 	var sentences = [];
 	var currentSentence = "";
 
-	// Use temporary placeholders to prevent splitting inside numbers
+	// Use temporary placeholders to prevent splitting inside numbers or special terms like "i.e." or "e.g."
 	text = text.replace(/(\d),(\d)/g, '$1\x01$2');
 	text = text.replace(/(\d)\.(\d)/g, '$1\x02$2');
+	text = text.replace(/i\.e\./g, 'i\x03e');
+	text = text.replace(/e\.g\./g, 'e\x04g');
 
 	for (var i = 0; i < text.length; i++) {
 		var currentChar = text[i];
@@ -467,7 +469,7 @@ function CN_SplitIntoSentences(text) {
 		) {
 			if (currentSentence.trim() !== "") {
 				// Replace placeholders back to original strings
-				currentSentence = currentSentence.replace(/\x01/g, ',').replace(/\x02/g, '.');
+				currentSentence = currentSentence.replace(/\x01/g, ',').replace(/\x02/g, '.').replace(/\x03/g, '.').replace(/\x04/g, '.');
 				sentences.push(currentSentence.trim());
 			}
 			currentSentence = "";
@@ -477,10 +479,10 @@ function CN_SplitIntoSentences(text) {
 	// Add last sentence if any
 	if (currentSentence.trim() !== "") {
 		// Replace placeholders back to original strings
-		currentSentence = currentSentence.replace(/\x01/g, ',').replace(/\x02/g, '.');
+		currentSentence = currentSentence.replace(/\x01/g, ',').replace(/\x02/g, '.').replace(/\x03/g, '.').replace(/\x04/g, '.');
 		sentences.push(currentSentence.trim());
 	}
-	
+
 	return sentences;
 }
 


### PR DESCRIPTION
## What
This PR solves #118 and the problem of extra sentence breaks for words like `i.e.` in the relevant function.

## Preview
Several cases were tested.

Before
```javascript
console.log(CN_SplitIntoSentences("The expenses came up to 1,550,309.56 TRY."));
/*
[
    "The expenses came up to 1,",
    "550,",
    "309.",
    "56 TRY."
]
*/

console.log(CN_SplitIntoSentences("Harcamalar 1.550.309,56 TL tuttu.");
/*
[
    "Harcamalar 1.",
    "550.",
    "309,",
    "56 TL tuttu."
]
*/

console.log(CN_SplitIntoSentences("The amount, i.e., 1,234,567.89, is significant.");
/*
[
    "The amount,",
    "i.",
    "e.",
    ",",
    "1,",
    "234,",
    "567.",
    "89,",
    "is significant."
]
*/
```

After
```javascript
console.log(CN_SplitIntoSentences("The expenses came up to 1,550,309.56 TRY."));
/*
[
    "The expenses came up to 1,550,309.56 TRY."
]
*/ 

console.log(CN_SplitIntoSentences("Harcamalar 1.550.309,56 TL tuttu.");
/*
[
    "Harcamalar 1.550.309,56 TL tuttu."
]
*/

console.log(CN_SplitIntoSentences("The amount, i.e., 1,234,567.89, is significant.");
/*
[
    "The amount,",
    "i.e,",
    "1,234,567.89,",
    "is significant."
]
*/
```

