### PR TITLE
fix breaking sentence issue

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -434,39 +434,57 @@ function CN_KeepSpeechSynthesisActive() {
 function CN_SplitIntoSentences(text) {
 	var sentences = [];
 	var currentSentence = "";
-	
-	for(var i=0; i<text.length; i++) {
-		//
+
+	// Use temporary placeholders to prevent splitting inside numbers
+	text = text.replace(/(\d),(\d)/g, '$1†$2');
+	text = text.replace(/(\d)\.(\d)/g, '$1‡$2');
+
+	for (var i = 0; i < text.length; i++) {
 		var currentChar = text[i];
-		
+
 		// Add character to current sentence
 		currentSentence += currentChar;
-		
+
 		// is the current character a delimiter? if so, add current part to array and clear
 		if (
 			// Latin punctuation
-		       currentChar == (CN_IGNORE_COMMAS?'.':',')
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : ':')
-			|| currentChar == '.' 
-			|| currentChar == '!' 
-			|| currentChar == '?' 
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : ';')
-			|| currentChar == '…'
-			// Chinese/japanese punctuation
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '、')
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '，')
-			|| currentChar == '。'
-			|| currentChar == '．'
-			|| currentChar == '！'
-			|| currentChar == '？'
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '；')
-			|| currentChar == (CN_IGNORE_COMMAS ? '.' : '：')
-			) {
-			if (currentSentence.trim() != "") sentences.push(currentSentence.trim());
+			currentChar == (CN_IGNORE_COMMAS ? '.' : ',') ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : ':') ||
+			currentChar == '.' ||
+			currentChar == '!' ||
+			currentChar == '?' ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : ';') ||
+			currentChar == '…' ||
+			// Chinese/Japanese punctuation
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '、') ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '，') ||
+			currentChar == '。' ||
+			currentChar == '．' ||
+			currentChar == '！' ||
+			currentChar == '？' ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '；') ||
+			currentChar == (CN_IGNORE_COMMAS ? '.' : '：')
+		) {
+			// when the text is a part such as "It is 3." (-> "It is 3.14"), should not split
+			// when text[i] is a dot comma, and text[i-1] and text[i+1] are numbers, then it is a decimal number, so continue
+			// but text[i+1] is " ", then it is not a decimal number, so not continue
+
+			if (i > 0 && i < text.length - 1) {
+				// when this conditions include  && text[i + 1] !== " ", "It is 3.14, however," will be split into "It is 3.14," and "however,"
+				if (currentChar == (CN_IGNORE_COMMAS ? '.' : ',') && !isNaN(text[i - 1]) && !isNaN(text[i + 1])) {
+					console.log("PASSING NOW")
+					continue;
+				}
+			}
+			if (currentSentence.trim() !== "") {
+				// Replace placeholders back to original strings
+				currentSentence = currentSentence.replace(/†/g, ',').replace(/‡/g, '.');
+				sentences.push(currentSentence.trim());
+			}
 			currentSentence = "";
 		}
 	}
-	
+
 	return sentences;
 }
 


### PR DESCRIPTION
Hello, this is a modified pull request. Please forgive my frequent requests for reviews.

## What
This PR tries to solve #118 .

## How
As the following, when a period or comma is between numbers, temporarily convert it to a placeholder and back to the end.
```Javascript
text = text.replace(/(\d),(\d)/g, '$1†$2');
text = text.replace(/(\d)\.(\d)/g, '$1‡$2');
```

However, I am considering the case where the sentence being input to this function is in the middle of a sentence. This phenomenon is inevitable because sentences are usually entered into `CN_SplitIntoSentences` even in the process of generation.

When this phenomenon occurs, problems arise. For example, if the sentence "**The expences came up 1,500,500**" was entered up to "**The expences came up 1,500,**" if the sentence was separated there, the "**,500**" would be **lost**. 

**”Lost"** means as in the following image
![image](https://github.com/C-Nedelcu/talk-to-chatgpt/assets/11631971/0d4773f8-43e9-44be-81c5-ae2cb2b7673f)


This problem occurs because "a period/comma at the end of a sentence is not considered part of the number" and occurs when a complete sentence is entered later.

Therefore, a function has been added to prevent this from happening. On the other hand, if "**The expences came up 1,500, however**" is entered in this case, there is a side-effect that the delimiter is **not placed** before "**however**".

But, we can now handle commas and periods correctly. (except in the case of i.e., ... )